### PR TITLE
Feature/neutral support

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,14 +19,17 @@ Example result:
 (boolean) true 
 */
 
-Badwords::isDirtyNegate("You are not an asshole");
+Badwords::negationCheck("You are not an asshole");
 /*
 When string contains a negator like not, aren't, etc before the offensive word
-it returns 1
+it returns 0
 Output:
 -1 means NOT FOUND
-0 means found but no negator (const NEGATE) found before the offensive word 
-1 means found with a negator (const NEGATE) before the offensive word  
+0 means found with a negator before the offensive word (Neutral)
+1 means offensive word was found
+
+Note: The negator can appear before an article just like the example above, or directly before the bad word
+E.g of articles: "a", "an", "the"
 */
 
 Badwords::strip('Blood sugar sex magic');

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Badwords::isDirtyNegate("You are not an asshole");
 /*
 When string contains a negator like not, aren't, etc before the offensive word
 it returns 1
-Output
+Output:
 -1 means NOT FOUND
 0 means found but no negator (const NEGATE) found before the offensive word 
 1 means found with a negator (const NEGATE) before the offensive word  

--- a/README.md
+++ b/README.md
@@ -19,6 +19,16 @@ Example result:
 (boolean) true 
 */
 
+Badwords::isDirtyNegate("You are not an asshole");
+/*
+When string contains a negator like not, aren't, etc before the offensive word
+it returns 1
+Output
+-1 means NOT FOUND
+0 means found but no negator (const NEGATE) found before the offensive word 
+1 means found with a negator (const NEGATE) before the offensive word  
+*/
+
 Badwords::strip('Blood sugar sex magic');
 
 /*

--- a/spec/badwords.spec.php
+++ b/spec/badwords.spec.php
@@ -43,4 +43,49 @@ describe("Badwords", function () {
             });
         });
     });
+
+    describe("negationCheck()", function() {
+        context("when sentence doesn't contain bad word", function(){
+            it("returns -1 when no bad word is found", function() {
+                expect(
+                    Badwords::negationCheck("I am Jerespy")
+                )->toBe(-1);
+            });
+        });
+
+        context("when sentence contains a bad word but contains a negator before the bad word", function() {
+            it("return 0 when a negator appeare before bad word", function() {
+                expect(
+                    Badwords::negationCheck("I am an not asshole")
+                )->toBe(0);
+            });
+        });
+
+        context("when sentence contains a bad word", function() {
+            it("return 1 when a bad word is present in the sentence", function() {
+                expect(
+                    Badwords::negationCheck("blood sugar sex magic")
+                )->toBe(1);
+            });
+        });
+    });
+
+    describe("getBadword()", function (){
+        context("return bad word from a sentence", function() {
+            it("return bad word in sentence", function() {
+                expect(
+                    Badwords::getBadword("I am an not asshole")
+                )->toBe("asshole");
+            });
+        });
+
+        context("return -1 from a sentence, if no bad word was found", function() {
+            it("return -1", function() {
+                expect(
+                    Badwords::getBadword("I am Jerespy")
+                )->toBe(-1);
+            });
+        });
+    });
+
 });

--- a/src/Badwords.php
+++ b/src/Badwords.php
@@ -5,6 +5,18 @@
  */
 class Badwords
 {
+    const NEGATE = ["aint", "arent", "cannot", "cant", "couldnt", "darent", "didnt", "doesnt",
+        "ain't", "aren't", "can't", "couldn't", "daren't", "didn't", "doesn't",
+        "dont", "hadnt", "hasnt", "havent", "isnt", "mightnt", "mustnt", "neither",
+        "don't", "hadn't", "hasn't", "haven't", "isn't", "mightn't", "mustn't",
+        "neednt", "needn't", "never", "no", "none", "nope", "nor", "not", "nothing", "nowhere",
+        "oughtnt", "shant", "shouldnt", "uhuh", "wasnt", "werent",
+        "oughtn't", "shan't", "shouldn't", "uh-uh", "wasn't", "weren't",
+        "without", "wont", "wouldnt", "won't", "wouldn't", "rarely", "seldom", "despite"];
+
+    const ARTICLE = ["a", "an", "the"];
+
+
     public static function isDirty($string)
     {
         $words = explode(" ", $string);
@@ -24,7 +36,7 @@ class Badwords
             }
         }
 
-        return false;
+        return 0;
     }
 
     public static function strip($string)
@@ -55,6 +67,89 @@ class Badwords
         return array_map(function ($item) {
             return strtolower(trim($item));
         }, explode("\n", file_get_contents(__DIR__ . "/badwords.txt")));
+    }
+
+    // Return a single bad word found in the sentence
+    public static function getBadword($sentence)
+    {
+        $isDirty = self::isDirty($sentence);
+        
+        // List of badwords
+        $getBadWords = self::getBadWords();
+        if($isDirty == 1)
+        {
+        // Offensive word is found
+        // return the word 
+            $sentenceArray = explode(" ", strtolower($sentence));
+            for($i = 0; $i < count($sentenceArray); $i++)
+                    for ($k=0; $k < count($getBadWords); $k++) { 
+                    
+                    {
+                            if ($sentenceArray[$i] == $getBadWords[$k]) {
+                                return $getBadWords[$k];
+                            }
+                    }
+            }
+
+
+        }
+        return -1;     
+    }
+
+    public static function isDirtyNegate($sentence)
+    {
+        // Output
+        // -1 means NOT FOUND
+        // 0 means found but no negator (const NEGATE) found before the offensive word
+        // 1 means found with a negator (const NEGATE) before the offensive word
+        
+        // Bad word in the sentence 
+        $getBadWord = Badwords::getBadword(strtolower(trim(($sentence))));
+        if($getBadWord == -1)
+        {
+            return -1;
+        }
+        
+        // Checking if the word b4 the offensive word is negator
+        $findme = $getBadWord;
+        $pos = strpos($sentence, $findme);
+        $newSentence = explode(" ",trim(substr($sentence, 0, $pos)));
+        // Getting the last word in the array.
+        $last_word = end($newSentence);
+
+        // check if it's an article b4 the fowl word
+        if(Badwords::checkWord($last_word,'ARTICLE') == 1)
+        {
+            //Checking the word after the ARTICLE
+            array_pop($newSentence);
+            $newLastWord = end($newSentence);
+            if (Badwords::checkWord($last_word,'NEGAGE') == 1) {
+                return 1;
+            }
+            else
+            {
+                return -1;
+            }
+        }
+        else if(Badwords::checkWord($last_word,'NEGAGE') == 1)
+        {
+            return 1;
+        }
+
+        return 0;
+    }
+
+    public static function checkWord($word,$const)
+    {
+        $constant = ($const == "NEGATE") ? self::NEGATE : self::ARTICLE;
+        // print_r($constant);
+        foreach($constant as $value)
+        {
+            if ($value == $word) {
+                return 1;
+            }
+        }
+        return 0;
     }
 
     public static function getBadPhrases()

--- a/src/Badwords.php
+++ b/src/Badwords.php
@@ -66,26 +66,22 @@ class Badwords
         }, explode("\n", file_get_contents(__DIR__ . "/badwords.txt")));
     }
 
-    // Return a single bad word found in the sentence
     public static function getBadword($sentence)
     {
         $isDirty = self::isDirty($sentence);
         
-        // List of badwords
         $getBadWords = self::getBadWords();
         if($isDirty == 1)
-        {
-        // Offensive word is found
-        // return the word 
+        { 
             $sentenceArray = explode(" ", strtolower($sentence));
             for($i = 0; $i < count($sentenceArray); $i++)
-                    for ($k=0; $k < count($getBadWords); $k++) { 
-                    
-                    {
-                            if ($sentenceArray[$i] == $getBadWords[$k]) {
-                                return $getBadWords[$k];
-                            }
+                for ($k=0; $k < count($getBadWords); $k++) { 
+                
+                {
+                    if ($sentenceArray[$i] == $getBadWords[$k]) {
+                        return $getBadWords[$k];
                     }
+                }
             }
 
 
@@ -106,17 +102,13 @@ class Badwords
             return $notFound;
         }
         
-        // Checking if the word b4 the offensive word is negator
         $findme = $getBadWord;
         $pos = strpos($sentence, $findme);
         $precedingWords = explode(" ",trim(substr($sentence, 0, $pos)));
-        // Getting the last word in the array.
         $last_word = end($precedingWords);
 
-        // check if it's an article b4 the fowl word
         if(Badwords::checkWord($last_word,'ARTICLE') == 1)
         {
-            //Checking the word before the ARTICLE
             return Badwords::checkWord(prev($precedingWords),'NEGATOR') == 1 ? $isNeutral : $isBadWord;
         }
         

--- a/src/Badwords.php
+++ b/src/Badwords.php
@@ -1,6 +1,7 @@
 <?php namespace Buchin\Badwords;
 
 /**
+ * Updated by: Osah Prince
  *
  */
 class Badwords
@@ -104,6 +105,7 @@ class Badwords
         // 1 means found with a negator (const NEGATE) before the offensive word
         
         // Bad word in the sentence 
+        $sentence = preg_replace('/(\s\s+|\t|\n)/', ' ', $sentence);
         $getBadWord = Badwords::getBadword(strtolower(trim(($sentence))));
         if($getBadWord == -1)
         {
@@ -113,7 +115,7 @@ class Badwords
         // Checking if the word b4 the offensive word is negator
         $findme = $getBadWord;
         $pos = strpos($sentence, $findme);
-        $newSentence = explode(" ",trim(substr($sentence, 0, $pos)));
+        $newSentence = explode(" ",trim(substr(strtolower($sentence), 0, $pos)));
         // Getting the last word in the array.
         $last_word = end($newSentence);
 
@@ -123,19 +125,21 @@ class Badwords
             //Checking the word after the ARTICLE
             array_pop($newSentence);
             $newLastWord = end($newSentence);
-            if (Badwords::checkWord($last_word,'NEGAGE') == 1) {
+            // echo "NEGATE ($newLastWord) == ". Badwords::checkWord($newLastWord,'NEGATE');
+            if (Badwords::checkWord($newLastWord,'NEGATE') == 1) {
+                // Found with a negator
                 return 1;
             }
             else
             {
-                return -1;
+                // Found without a negator
+                return 0;
             }
         }
-        else if(Badwords::checkWord($last_word,'NEGAGE') == 1)
+        else if(Badwords::checkWord($last_word,'NEGATE') == 1)
         {
             return 1;
         }
-
         return 0;
     }
 

--- a/src/Badwords.php
+++ b/src/Badwords.php
@@ -1,12 +1,8 @@
 <?php namespace Buchin\Badwords;
 
-/**
- * Updated by: Osah Prince
- *
- */
 class Badwords
 {
-    const NEGATE = ["aint", "arent", "cannot", "cant", "couldnt", "darent", "didnt", "doesnt",
+    const NEGATOR = ["aint", "arent", "cannot", "cant", "couldnt", "darent", "didnt", "doesnt",
         "ain't", "aren't", "can't", "couldn't", "daren't", "didn't", "doesn't",
         "dont", "hadnt", "hasnt", "havent", "isnt", "mightnt", "mustnt", "neither",
         "don't", "hadn't", "hasn't", "haven't", "isn't", "mightn't", "mustn't",
@@ -37,7 +33,7 @@ class Badwords
             }
         }
 
-        return 0;
+        return false;
     }
 
     public static function strip($string)
@@ -97,63 +93,46 @@ class Badwords
         return -1;     
     }
 
-    public static function isDirtyNegate($sentence)
+    public static function negationCheck($sentence)
     {
-        // Output
-        // -1 means NOT FOUND
-        // 0 means found but no negator (const NEGATE) found before the offensive word
-        // 1 means found with a negator (const NEGATE) before the offensive word
+        $isBadWord = 1;
+        $isNeutral = 0;
+        $notFound = -1;
         
-        // Bad word in the sentence 
-        $sentence = preg_replace('/(\s\s+|\t|\n)/', ' ', $sentence);
-        $getBadWord = Badwords::getBadword(strtolower(trim(($sentence))));
+        $sentence = preg_replace('/(\s\s+|\t|\n)/', ' ', strtolower(trim($sentence)));
+        $getBadWord = Badwords::getBadword(($sentence));
         if($getBadWord == -1)
         {
-            return -1;
+            return $notFound;
         }
         
         // Checking if the word b4 the offensive word is negator
         $findme = $getBadWord;
         $pos = strpos($sentence, $findme);
-        $newSentence = explode(" ",trim(substr(strtolower($sentence), 0, $pos)));
+        $precedingWords = explode(" ",trim(substr($sentence, 0, $pos)));
         // Getting the last word in the array.
-        $last_word = end($newSentence);
+        $last_word = end($precedingWords);
 
         // check if it's an article b4 the fowl word
         if(Badwords::checkWord($last_word,'ARTICLE') == 1)
         {
-            //Checking the word after the ARTICLE
-            array_pop($newSentence);
-            $newLastWord = end($newSentence);
-            // echo "NEGATE ($newLastWord) == ". Badwords::checkWord($newLastWord,'NEGATE');
-            if (Badwords::checkWord($newLastWord,'NEGATE') == 1) {
-                // Found with a negator
-                return 1;
-            }
-            else
-            {
-                // Found without a negator
-                return 0;
-            }
+            //Checking the word before the ARTICLE
+            return Badwords::checkWord(prev($precedingWords),'NEGATOR') == 1 ? $isNeutral : $isBadWord;
         }
-        else if(Badwords::checkWord($last_word,'NEGATE') == 1)
-        {
-            return 1;
-        }
-        return 0;
+        
+        return (Badwords::checkWord($last_word,'NEGATOR') == 1) ? $isNeutral : $isBadWord;
     }
 
     public static function checkWord($word,$const)
     {
-        $constant = ($const == "NEGATE") ? self::NEGATE : self::ARTICLE;
-        // print_r($constant);
+        $constant = ($const == "NEGATOR") ? self::NEGATOR : self::ARTICLE;
         foreach($constant as $value)
         {
             if ($value == $word) {
                 return 1;
             }
         }
-        return 0;
+        return -1;
     }
 
     public static function getBadPhrases()


### PR DESCRIPTION
The functionality added identifies whether an offensive (bad) word found in a given sentence is negated by context. Specifically, it determines if a negator (e.g., "not", "never", "no") precedes the offensive word, altering its meaning to a neutral or non-offensive state.